### PR TITLE
SUP-1 Include the RHDZMOTA package as the main dependency

### DIFF
--- a/rhdzmota_support/requirements.txt
+++ b/rhdzmota_support/requirements.txt
@@ -1,3 +1,1 @@
-fire==0.5.0
-streamlit==1.31.1
-sentry_sdk==1.40.6
+rhdzmota[ext.streamlit_webapps]<5.0.0


### PR DESCRIPTION
# SUP-1 Include the RHDZMOTA package as the main dependency
* Closes: #1 

This PR adds the following dependencies:
* `rhdzmota`
* `rhdzmota-extension-streamlit-webapps`

As a result, all other dependencies were replaced. 